### PR TITLE
feat: decorate references in the document

### DIFF
--- a/us/en/skymiles/scripts/scripts.js
+++ b/us/en/skymiles/scripts/scripts.js
@@ -31,9 +31,24 @@ function decorateScreenReaderOnly(container) {
   [...container.querySelectorAll('del')].forEach((el) => {
     const span = document.createElement('span');
     span.classList.add('sr-only');
-    span.textContent = el.textContent;
+    span.innerHTML = el.innerHTML;
     el.replaceWith(span);
   });
+}
+
+function decorateReferences(container) {
+  const REFERENCE_TOKENS = /(\*+|[†‡])/g;
+  [...container.querySelectorAll('p,a,li')]
+    .forEach((el) => {
+      el.innerHTML = el.innerHTML.replace(REFERENCE_TOKENS, (token) => `<sup>${token}</sup>`);
+    });
+  [...container.querySelectorAll('p')]
+    .filter((p) => p.children.length && [...p.children].every((c) => c.nodeName === 'EM' || c.firstChild.nodeName === 'EM'))
+    .forEach((el) => {
+      const small = document.createElement('small');
+      small.innerHTML = el.innerHTML.replace(/<\\?em>/g, '');
+      el.innerHTML = small.outerHTML;
+    });
 }
 
 /**
@@ -44,6 +59,7 @@ function buildAutoBlocks(main) {
   try {
     buildHeroBlock(main);
     decorateScreenReaderOnly(main);
+    decorateReferences(main);
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('Auto Blocking failed', error);


### PR DESCRIPTION
Decorates inline references (`*`, `**`, `†`, `‡`, …).

Fix #43 , #44 

Test URLs:
- Before: https://main--delta--hlxsites.hlx.page/us/en/skymiles/how-to-earn-miles/overview
- After: https://issue-44--delta--hlxsites.hlx.page/us/en/skymiles/how-to-earn-miles/overview
