### PR TITLE
feat: style the table block with 3 variants

### DIFF
--- a/us/en/skymiles/blocks/table/table.css
+++ b/us/en/skymiles/blocks/table/table.css
@@ -1,0 +1,151 @@
+.table {
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+.table .button-container:only-child {
+  margin: 0;
+}
+
+.table .button {
+  padding: .5rem;
+  min-width: 0;
+  vertical-align: bottom;
+}
+
+.table table {
+  border-collapse: collapse;
+}
+
+.table tr > :is(th, td) {
+  border-bottom: 1px solid var(--color-delta-gray-middle2);
+  color: var(--color-delta-blue);
+}
+
+.table th,
+.table td {
+  padding: 2rem;
+  text-align: center;
+}
+
+.table thead th {
+  font-family: var(--heading-font-family-alt);
+}
+
+.table button[data-role="prev"],
+.table button[data-role="next"] {
+  position: absolute;
+  top: 2rem;
+  border: none;
+  padding: 1rem;
+  min-width: unset;
+  background: none;
+  transition: top .3s ease-out;
+}
+
+.table button[data-role="prev"] {
+  left: 50%;
+}
+
+.table button[data-role="next"] {
+  right: 0;
+}
+
+.table button:is([data-role="prev"], [data-role="next"]) svg {
+  fill: var(--color-delta-red);
+  height: 24px;
+  width: 24px;
+}
+
+.table button:is([data-role="prev"], [data-role="next"]):is(:hover, :focus) {
+  background: none;
+}
+
+.table button:is([data-role="prev"], [data-role="next"]):disabled {
+  opacity: .2;
+}
+
+.table button[data-role="prev"] svg {
+  transform: rotateZ(90deg);
+}
+
+.table button[data-role="next"] svg {
+  transform: rotateZ(-90deg);
+}
+
+.table p {
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.table p:only-child {
+  margin: 0;
+}
+
+/* The mobile list variant. */
+
+.table.list dl {
+  display: flex;
+  flex-wrap: wrap;
+  border: 1px solid var(--color-delta-gray-middle2);
+  border-width: 1px 1px 0;
+}
+
+.table.list dl:nth-of-type(2n) {
+  background-color: var(--color-delta-gray-light);
+}
+
+.table.list dt {
+  box-sizing: border-box;
+  width: 50%;
+  padding: 1rem;
+  border-bottom: 1px solid var(--color-delta-gray-middle2);
+}
+
+.table.list dd {
+  box-sizing: border-box;
+  margin: 0;
+  width: 50%;
+  padding: 1rem;
+  border-left: 1px solid var(--color-delta-gray-middle2);
+  border-bottom: 1px solid var(--color-delta-gray-middle2);
+}
+
+/* The silent table variant. */
+
+.table.silent :is(table, th, td) {
+  border: none;
+}
+
+/* The emphasized table variant. */
+
+.table.emphasized :is(table, th, td) {
+  border: 1px solid var(--color-delta-gray-middle2);
+  border-width: 0 1px 1px;
+}
+
+/* The sticky mobile nav table variant. */
+
+.table.is-sticky-nav button:is([data-role="prev"], [data-role="next"]) {
+  position: fixed;
+  top: 50%;
+}
+
+@media (min-width: 992px) {
+  .table button:is([data-role="prev"], [data-role="next"]) {
+    display: none;
+  }
+
+  .table .button {
+    padding: .5rem 1rem;
+    min-width: 0;
+    vertical-align: bottom;
+  }
+
+  .table:not(.silent) thead th:first-child {
+    padding: 1rem 2rem;
+    font-family: var(--body-font-family);
+    font-size: 2rem;
+    font-weight: 300;
+  }
+}

--- a/us/en/skymiles/blocks/table/table.js
+++ b/us/en/skymiles/blocks/table/table.js
@@ -1,0 +1,106 @@
+import { decorateButtons, decorateIcons } from '../../scripts/lib-franklin.js';
+
+function toggleVisibleColumns(block, indexes) {
+  const width = 100 / indexes.length;
+  block.querySelectorAll('table tr > *').forEach((cell) => {
+    const index = Array.prototype.indexOf.call(cell.parentNode.children, cell);
+    cell.style.display = indexes.includes(index) ? 'table-cell' : 'none';
+    cell.style.width = `${width}%`;
+  });
+}
+
+function navClickHandler(ev) {
+  ev.preventDefault();
+  const block = ev.target.closest('.block');
+  const table = block.querySelector('table');
+  const colCount = table.querySelector('thead > tr').children.length;
+  let visibleIndex = table.visibleColIndex;
+  if (ev.currentTarget.dataset.role === 'prev') {
+    visibleIndex = Math.max(visibleIndex - 1, 1);
+  } else if (ev.currentTarget.dataset.role === 'next') {
+    visibleIndex = Math.min(visibleIndex + 1, colCount - 1);
+  } else {
+    return;
+  }
+
+  block.querySelector('button[data-role="prev"]').disabled = visibleIndex === 1;
+  block.querySelector('button[data-role="next"]').disabled = visibleIndex === colCount - 1;
+  toggleVisibleColumns(block, [0, visibleIndex]);
+  table.visibleColIndex = visibleIndex;
+}
+
+export default function decorate(block) {
+  const table = document.createElement('table');
+  const thead = document.createElement('thead');
+  table.append(thead);
+
+  const tbody = document.createElement('tbody');
+  table.append(tbody);
+
+  [...block.children].forEach((row, i) => {
+    const tr = document.createElement('tr');
+    [...row.children].forEach((c, j) => {
+      const cell = document.createElement(i > 0 && j > 0 ? 'td' : 'th');
+      cell.innerHTML = `<p>${c.innerHTML}</p>`;
+      tr.append(cell);
+    });
+    (i > 0 ? tbody : thead).append(tr);
+  });
+  block.innerHTML = table.outerHTML;
+
+  if (window.innerWidth < 992 && block.classList.contains('list')) {
+    const columnsCount = block.firstElementChild.children.length;
+    const div = document.createElement('div');
+    for (let i = 1; i < columnsCount; i += 1) {
+      const dl = document.createElement('dl');
+      [...block.children].forEach((c) => {
+        const dt = document.createElement('dt');
+        dt.innerHTML = c.children[0].innerHTML;
+        dl.append(dt);
+        const dd = document.createElement('dd');
+        dd.innerHTML = c.children[i].innerHTML;
+        dl.append(dd);
+      });
+      div.append(dl);
+    }
+    block.innerHTML = div.outerHTML;
+  } else if (window.innerWidth < 992) {
+    const DEFAULT_VISIBLE_COL_INDEX = 1;
+    const ICON = '<span class="icon icon-down-chevron"></span>';
+    block.querySelector('table').visibleColIndex = DEFAULT_VISIBLE_COL_INDEX;
+    const nextButton = document.createElement('button');
+    nextButton.dataset.role = 'next';
+    nextButton.innerHTML = ICON;
+    nextButton.addEventListener('click', navClickHandler);
+    block.prepend(nextButton);
+
+    const prevButton = document.createElement('button');
+    prevButton.dataset.role = 'prev';
+    prevButton.disabled = true;
+    prevButton.innerHTML = ICON;
+    prevButton.addEventListener('click', navClickHandler);
+    block.prepend(prevButton);
+    toggleVisibleColumns(block, [0, DEFAULT_VISIBLE_COL_INDEX]);
+  }
+
+  decorateIcons(block);
+  decorateButtons(block);
+}
+
+window.addEventListener('scroll', () => {
+  if (window.innerWidth >= 992) {
+    return;
+  }
+  document.querySelectorAll('.table').forEach((block) => {
+    const rect = block.getBoundingClientRect();
+    const shouldStickyNav = rect.top < 100 && rect.height + rect.y > 100;
+    const isAlreadyStickyNav = block.classList.contains('is-sticky-nav');
+    if (isAlreadyStickyNav === shouldStickyNav) {
+      return;
+    }
+    block.classList.toggle('is-sticky-nav', shouldStickyNav);
+    block.querySelector('button[data-role="next"]').style.right = shouldStickyNav
+      ? `${(window.innerWidth - rect.width) / 2}px`
+      : '';
+  });
+}, { passive: true });


### PR DESCRIPTION
The PR introduces the `table` block for plain data tables, and includes 3 styles (default, `silent` and `emphasized`).

Fix #66 

Test URLs:
- Before: https://main--delta--hlxsites.hlx.page/drafts/alex/import/us/en/skymiles/airline-credit-cards/american-express-business-cards
- After: https://issue-66--delta--hlxsites.hlx.page/drafts/alex/import/us/en/skymiles/airline-credit-cards/american-express-business-cards
