### PR TITLE
feat: add support for async accordion loading

### DIFF
--- a/us/en/skymiles/blocks/accordion/accordion.js
+++ b/us/en/skymiles/blocks/accordion/accordion.js
@@ -1,3 +1,6 @@
+import { decorateBlock, loadBlocks } from '../../scripts/lib-franklin.js';
+import { fetchContent } from '../../scripts/scripts.js';
+
 export default async function decorate(block) {
   const accordions = [...block.children];
   accordions.forEach((accordion) => {
@@ -11,9 +14,35 @@ export default async function decorate(block) {
     children[1].classList.add('text');
   }));
 
-  // creating buttons in text divs
-  const textDiv = block.querySelectorAll('.text');
-  textDiv.forEach((text) => {
+  const textDivs = block.querySelectorAll('.text');
+
+  // fetch dynamic content
+  let hasAsyncBlocks = false;
+  await Promise.all([...textDivs].map(async (text) => {
+    if (text.children.length === 1 && text.firstElementChild.tagName === 'A') {
+      try {
+        const path1 = new URL(text.firstElementChild.textContent).pathname;
+        const path2 = new URL(text.firstElementChild.href).pathname;
+        if (path1 !== path2) {
+          return;
+        }
+        const content = await fetchContent(path2);
+        text.classList.remove('button-container');
+        text.innerHTML = '';
+        text.appendChild(content);
+        text.firstElementChild.querySelectorAll(':scope > div')
+          .forEach(decorateBlock);
+        hasAsyncBlocks = true;
+      } catch (err) {
+        text.parentElement.remove();
+      }
+    }
+  }));
+  if (hasAsyncBlocks) {
+    await loadBlocks(document.querySelector('main'));
+  }
+
+  textDivs.forEach((text) => {
     const textButton = text.querySelectorAll('p > small > strong');
     textButton.forEach((tb) => {
       const button = document.createElement('button');
@@ -24,58 +53,50 @@ export default async function decorate(block) {
     });
   });
 
-  const parentWrapper = document.querySelectorAll('.accordion-wrapper');
-  parentWrapper.forEach((wrapper) => {
-    if (!wrapper.querySelector('.toolbar')) {
-      // Create the toolbar div
-      const toolbar = document.createElement('div');
-      toolbar.classList.add('toolbar');
+  /* The with-controls variant adds expand/collapse all buttons */
+  if (block.classList.contains('with-controls')) {
+    // Create the toolbar div
+    const toolbar = document.createElement('div');
+    toolbar.classList.add('toolbar');
 
-      // Create the Expand All button
-      const expandButton = document.createElement('button');
-      expandButton.classList.add('tertiary');
-      expandButton.classList.add('expand', 'highlight');
-      expandButton.textContent = 'Expand All';
-      toolbar.appendChild(expandButton);
+    // Create the Expand All button
+    const expandButton = document.createElement('button');
+    expandButton.classList.add('tertiary');
+    expandButton.classList.add('expand', 'highlight');
+    expandButton.textContent = 'Expand All';
+    toolbar.appendChild(expandButton);
 
-      // Create the Collapse All button
-      const collapseButton = document.createElement('button');
-      collapseButton.classList.add('tertiary');
-      collapseButton.classList.add('collapse');
-      collapseButton.textContent = 'Collapse All';
-      toolbar.appendChild(collapseButton);
+    // Create the Collapse All button
+    const collapseButton = document.createElement('button');
+    collapseButton.classList.add('tertiary');
+    collapseButton.classList.add('collapse');
+    collapseButton.textContent = 'Collapse All';
+    toolbar.appendChild(collapseButton);
 
-      wrapper.insertBefore(toolbar, wrapper.querySelector('.accordion.block'));
-      const headers = wrapper.querySelectorAll('.header');
+    block.parentElement.insertBefore(toolbar, block);
 
-      // add click events to expand and collapse buttons
-      expandButton.addEventListener('click', () => {
-        expandButton.classList.remove('highlight');
-        collapseButton.classList.toggle('highlight');
-        const texts = wrapper.querySelectorAll('.text');
-        for (let j = 0; j < texts.length; j += 1) {
-          const text = texts[j];
-          text.setAttribute('aria-expanded', 'true');
-        }
-        headers.forEach((header) => {
-          header.setAttribute('aria-expanded', 'true');
-        });
+    expandButton.addEventListener('click', () => {
+      expandButton.classList.remove('highlight');
+      collapseButton.classList.toggle('highlight');
+      block.querySelectorAll('.header').forEach((header) => {
+        header.setAttribute('aria-expanded', 'true');
       });
-
-      collapseButton.addEventListener('click', () => {
-        collapseButton.classList.toggle('highlight');
-        expandButton.classList.toggle('highlight');
-        const texts = wrapper.querySelectorAll('.text');
-        for (let j = 0; j < texts.length; j += 1) {
-          const text = texts[j];
-          text.setAttribute('aria-expanded', 'false');
-        }
-        headers.forEach((header) => {
-          header.setAttribute('aria-expanded', 'false');
-        });
+      block.querySelectorAll('.text').forEach((text) => {
+        text.setAttribute('aria-expanded', 'true');
       });
-    }
-  });
+    });
+
+    collapseButton.addEventListener('click', () => {
+      collapseButton.classList.remove('highlight');
+      expandButton.classList.toggle('highlight');
+      block.querySelectorAll('.header').forEach((header) => {
+        header.setAttribute('aria-expanded', 'false');
+      });
+      block.querySelectorAll('.text').forEach((text) => {
+        text.setAttribute('aria-expanded', 'false');
+      });
+    });
+  }
 
   // make content for accordion visible on header click
   const wrappers = block.querySelectorAll('.accordion-section');

--- a/us/en/skymiles/scripts/scripts.js
+++ b/us/en/skymiles/scripts/scripts.js
@@ -6,6 +6,7 @@ import {
   decorateButtons,
   decorateIcons,
   decorateSections,
+  decorateBlock,
   decorateBlocks,
   decorateTemplateAndTheme,
   waitForLCP,
@@ -64,12 +65,31 @@ function decorateResponsiveImages(container) {
     });
 }
 
-function decorateInlineToggles(container) {
-  function createInlineToggle(p) {
+async function decorateInlineToggles(container) {
+  async function createInlineToggle(p) {
     const details = document.createElement('details');
     const summary = document.createElement('summary');
     summary.innerHTML = p.innerHTML;
     details.append(summary);
+    if (p.nextElementSibling.children.length === 1 && p.nextElementSibling.firstElementChild.tagName === 'A') {
+      const a = p.nextElementSibling.firstElementChild;
+      try {
+        const path1 = new URL(a.textContent).pathname;
+        const path2 = new URL(a.href).pathname;
+        if (path1 === path2) {
+          // eslint-disable-next-line no-use-before-define
+          const content = await fetchContent(path2);
+          details.appendChild(content);
+          details.querySelectorAll(':scope > div')
+            .forEach(decorateBlock);
+          p.nextElementSibling.remove();
+          p.replaceWith(details);
+          return;
+        }
+      } catch (err) {
+        // Nothing to do here, just continue with regular decoration
+      }
+    }
     let next;
     do {
       next = p.nextElementSibling;
@@ -77,11 +97,11 @@ function decorateInlineToggles(container) {
     } while (next);
     p.replaceWith(details);
   }
-  container.querySelectorAll('p:has(.icon-toggle:first-child)')
-    .forEach(createInlineToggle);
-  [...container.querySelectorAll('p')]
+  await Promise.all([...container.querySelectorAll('p:has(.icon-toggle:first-child)')]
+    .map((el) => createInlineToggle(el)));
+  await Promise.all([...container.querySelectorAll('p')]
     .filter((p) => p.textContent.startsWith('> '))
-    .forEach(createInlineToggle);
+    .map((el) => createInlineToggle(el)));
 }
 
 // eslint-disable-next-line no-unused-vars
@@ -132,9 +152,9 @@ export function decorateReferences(container) {
     });
 }
 
-export function decorateContainer(container) {
+export async function decorateContainer(container) {
   decorateButtons(container);
-  decorateInlineToggles(container);
+  await decorateInlineToggles(container);
   decorateIcons(container);
   decorateResponsiveImages(container);
   decorateHyperlinkImages(container);
@@ -151,7 +171,7 @@ export async function fetchContent(url) {
     const html = await response.text();
     const wrapper = document.createElement('div');
     wrapper.innerHTML = html;
-    decorateContainer(wrapper.firstElementChild);
+    await decorateContainer(wrapper.firstElementChild);
     return wrapper.firstElementChild;
   } catch (err) {
     return Promise.reject(err);
@@ -185,9 +205,9 @@ function decorateEyeBrows(main) {
  * @param {Element} main The main element
  */
 // eslint-disable-next-line import/prefer-default-export
-export function decorateMain(main) {
+export async function decorateMain(main) {
   document.body.classList.add('fresh-air');
-  decorateContainer(main);
+  await decorateContainer(main);
   buildAutoBlocks(main);
   decorateSections(main);
   decorateBlocks(main);
@@ -210,7 +230,7 @@ async function loadEager(doc) {
   decorateTemplateAndTheme();
   const main = doc.querySelector('main');
   if (main) {
-    decorateMain(main);
+    await decorateMain(main);
     await waitForLCP(LCP_BLOCKS);
   }
 }

--- a/us/en/skymiles/scripts/scripts.js
+++ b/us/en/skymiles/scripts/scripts.js
@@ -6,6 +6,7 @@ import {
   decorateButtons,
   decorateIcons,
   decorateSections,
+  decorateBlock,
   decorateBlocks,
   decorateTemplateAndTheme,
   waitForLCP,
@@ -132,6 +133,32 @@ export function decorateReferences(container) {
     });
 }
 
+export function decorateContainer(container) {
+  decorateButtons(container);
+  decorateInlineToggles(container);
+  decorateIcons(container);
+  decorateResponsiveImages(container);
+  decorateHyperlinkImages(container);
+  decorateReferences(container);
+  // decorateScreenReaderOnly(main);
+}
+
+export async function fetchContent(url) {
+  try {
+    const response = await fetch(`${url}.plain.html`);
+    if (!response.ok) {
+      Promise.reject(new Error(`${response.status} - ${response.statusText}`));
+    }
+    const html = await response.text();
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = html;
+    decorateContainer(wrapper.firstElementChild);
+    return wrapper.firstElementChild;
+  } catch (err) {
+    return Promise.reject(err);
+  }
+}
+
 /**
  * Builds all synthetic blocks in a container element.
  * @param {Element} main The container element
@@ -161,15 +188,8 @@ function decorateEyeBrows(main) {
 // eslint-disable-next-line import/prefer-default-export
 export function decorateMain(main) {
   document.body.classList.add('fresh-air');
-  // hopefully forward compatible button decoration
-  decorateButtons(main);
-  decorateInlineToggles(main);
-  decorateIcons(main);
-  decorateResponsiveImages(main);
+  decorateContainer(main);
   buildAutoBlocks(main);
-  // decorateScreenReaderOnly(main);
-  decorateHyperlinkImages(main);
-  decorateReferences(main);
   decorateSections(main);
   decorateBlocks(main);
   decorateEyeBrows(main);

--- a/us/en/skymiles/scripts/scripts.js
+++ b/us/en/skymiles/scripts/scripts.js
@@ -6,7 +6,6 @@ import {
   decorateButtons,
   decorateIcons,
   decorateSections,
-  decorateBlock,
   decorateBlocks,
   decorateTemplateAndTheme,
   waitForLCP,


### PR DESCRIPTION
Adding support for dynamically loading the (inline) accordion content, including proper decoration of blocks etc. so that we can extract complex content blocks into separate "sub" pages and seamlessly render as a combined experience client-side.

Fix #85

Test URLs:
- Before:
  - https://main--delta--hlxsites.hlx.page/us/en/skymiles/medallion-program/international-partner-skyteam-benefits
  - https://main--delta--hlxsites.hlx.page/us/en/skymiles/medallion-program/medallion-upgrades
- After:
  - https://issue-85--delta--hlxsites.hlx.page/us/en/skymiles/medallion-program/international-partner-skyteam-benefits
  - https://issue-85--delta--hlxsites.hlx.page/us/en/skymiles/medallion-program/medallion-upgrades
