### PR TITLE
fix: open section nav should close on scroll

### DIFF
--- a/us/en/skymiles/blocks/section-nav/section-nav.css
+++ b/us/en/skymiles/blocks/section-nav/section-nav.css
@@ -98,11 +98,12 @@
   width: 100%;
 }
 
+.section-nav-toggle:focus,
 .section-nav-toggle:hover {
   background-color: inherit;
 }
 
-.section-nav-toggle h2 {
+.section-nav .section-nav-toggle h2 {
   margin: 0;
   font-family: inherit;
   font-size: inherit;
@@ -124,7 +125,7 @@
 }
 
 .section-nav-toggle[aria-expanded]::after {
-  top: 1.6rem;
+  top: 1.1rem;
   right: 2.5rem;
 }
 

--- a/us/en/skymiles/blocks/section-nav/section-nav.js
+++ b/us/en/skymiles/blocks/section-nav/section-nav.js
@@ -1,5 +1,6 @@
 import { constants } from './aria-menu.js';
 
+let lastScrollPosition;
 export default async function decorate(block) {
   block.innerHTML = '';
 
@@ -17,6 +18,9 @@ export default async function decorate(block) {
   element.setAttribute('aria-label', 'Site Section Navigation');
   element.querySelectorAll('ul').forEach((menu) => { menu.style.maxHeight = 0; });
   element.onToggle = (submenu, expanded) => {
+    if (expanded && submenu === element.querySelector('.section-nav-menu')) {
+      lastScrollPosition = window.scrollY;
+    }
     if (!expanded) {
       submenu.style.maxHeight = 0;
       return new Promise((resolve) => {
@@ -50,3 +54,13 @@ export default async function decorate(block) {
 
   block.append(current);
 }
+
+window.addEventListener('scroll', () => {
+  const menu = document.querySelector('.section-nav [role="menu"][aria-hidden="false"]');
+  if (!menu) {
+    return;
+  }
+  if (Math.abs(lastScrollPosition - window.scrollY) > 50) {
+    menu.closest('hlx-aria-menu').closeAll();
+  }
+}, { passive: true });


### PR DESCRIPTION
If the user scrolls for more than 50px from the opening point, we will close the section navigation menu. This allows for some minimal margin in case of unintentional scrolls, and for accessibility.

Fix #140

Test URLs:
- Before: https://main--delta--hlxsites.hlx.page/us/en/skymiles/how-to-earn-miles/overview
- After: https://issue-140--delta--hlxsites.hlx.page/us/en/skymiles/how-to-earn-miles/overview
